### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -18,7 +18,7 @@ https://poe.com/create_bot?server=1. You can also set this to None but certain f
 file output that mandate an `access_key` will not be available for your bot.
 - `should_insert_attachment_messages` (`bool = True`): A flag to decide whether to parse out
 content from attachments and insert them as messages into the conversation. This is set to
-`True`by default and we recommend leaving on since it allows your bot to comprehend attachments
+`True` by default and we recommend leaving on since it allows your bot to comprehend attachments
 uploaded by users by default.
 - `concat_attachments_to_message` (`bool = False`): **DEPRECATED**: Please set
 `should_insert_attachment_messages` instead.
@@ -80,7 +80,7 @@ default, this will call `get_settings`.
 
 Override this to record feedback from the user.
 #### Parameters:
-- `feedback_request` (`ReportFeedbackRequest`): An object representing the Feedback rqeuest
+- `feedback_request` (`ReportFeedbackRequest`): An object representing the Feedback request
 from Poe. This is sent out when a user provides feedback on a response on your bot.
 #### Returns: `None`
 
@@ -90,7 +90,7 @@ A version of `on_feedback` that also includes the request context information. B
 default, this will call `on_feedback`.
 
 #### Parameters:
-- `feedback_request` (`ReportFeedbackRequest`): An object representing a feedback rqeuest
+- `feedback_request` (`ReportFeedbackRequest`): An object representing a feedback request
 from Poe. This is sent out when a user provides feedback on a response on your bot.
 - `context` (`RequestContext`): an object representing the current HTTP request.
 #### Returns: `None`

--- a/src/fastapi_poe/base.py
+++ b/src/fastapi_poe/base.py
@@ -144,7 +144,7 @@ class PoeBot:
     file output that mandate an `access_key` will not be available for your bot.
     - `should_insert_attachment_messages` (`bool = True`): A flag to decide whether to parse out
     content from attachments and insert them as messages into the conversation. This is set to
-    `True`by default and we recommend leaving on since it allows your bot to comprehend attachments
+    `True` by default and we recommend leaving on since it allows your bot to comprehend attachments
     uploaded by users by default.
     - `concat_attachments_to_message` (`bool = False`): **DEPRECATED**: Please set
     `should_insert_attachment_messages` instead.
@@ -245,7 +245,7 @@ class PoeBot:
 
         Override this to record feedback from the user.
         #### Parameters:
-        - `feedback_request` (`ReportFeedbackRequest`): An object representing the Feedback rqeuest
+        - `feedback_request` (`ReportFeedbackRequest`): An object representing the Feedback request
         from Poe. This is sent out when a user provides feedback on a response on your bot.
         #### Returns: `None`
 
@@ -261,7 +261,7 @@ class PoeBot:
         default, this will call `on_feedback`.
 
         #### Parameters:
-        - `feedback_request` (`ReportFeedbackRequest`): An object representing a feedback rqeuest
+        - `feedback_request` (`ReportFeedbackRequest`): An object representing a feedback request
         from Poe. This is sent out when a user provides feedback on a response on your bot.
         - `context` (`RequestContext`): an object representing the current HTTP request.
         #### Returns: `None`


### PR DESCRIPTION
## Summary
- fix spacing typo in README documentation
- fix `rqeuest` typos in comments and docs

## Testing
- `ruff check .`