### PR TITLE
Fix capitalization of Poe in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Now, run your bot using `python <filename.py>`.
 - In a different terminal, run [ngrok](https://ngrok.com/) to make it publicly
   accessible.
 - Use the publicly accessible url to integrate your bot with
-  [poe](https://poe.com/create_bot?server=1)
+   [Poe](https://poe.com/create_bot?server=1)
 
 ### Enable authentication
 


### PR DESCRIPTION
## Summary
- fix case in README for the Poe link

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*